### PR TITLE
[Fix] Validate winery from wine-line when creating wines.

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -22,7 +22,7 @@ class Winery(models.Model):
 
     name = models.CharField(max_length=30)
     description = models.TextField()
-    website = models.CharField(max_length=40)
+    website = models.CharField(max_length=40, blank=True)
     available_since = models.DateTimeField(null=True, blank=True)
     location = PointField(u"longitude/latitude", geography=True, blank=True, null=True)
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -186,6 +186,17 @@ class WineSerializer(serializers.ModelSerializer):
         model = Wine
         fields = ('id', 'name', 'description', 'winery', 'varietal', 'wine_line')
 
+    def validate(self, data):
+        """Validate that the wine-line if from the same winery"""
+        try:
+            wine_line = WineLine.objects.get(name=data['wine_line'])
+            if wine_line.winery.id != data['winery'].id:
+                raise ValueError
+        except Exception:
+            raise serializers.ValidationError('The wine line specified does not match the same winery')
+
+        return data
+
 
 class EventBriefSerializer(serializers.ModelSerializer):
     """Serializer for event with rediced infromation only for reading purposes"""

--- a/api/tests/test_winery.py
+++ b/api/tests/test_winery.py
@@ -19,7 +19,7 @@ class TestWinery(TestCase):
         self.invalid_winery_data = {
                 'description': 'description',
         }
-        self.required_fields = set(['name', 'website'])
+        self.required_fields = set(['name', ])
         self.client = Client()
 
     def test_winery_creation(self):
@@ -109,6 +109,25 @@ class TestWines(TestCase):
         serializer = WineSerializer(data=self.invalid_wine_data)
         self.assertFalse(serializer.is_valid())
         self.assertEqual(set(serializer.errors), self.wine_required_fields)
+
+    def test_invalid_wine_creation_serializer(self):
+        """Test that when creating a wine the wine line is from the same winery"""
+        data = self.valid_wine_data
+        winery = Winery.objects.create(
+                name='Other winery',
+                description='Other',
+        )
+        wineline = WineLine.objects.create(
+            name='From other winery',
+            winery=winery,
+        )
+        data['wine_line'] = wineline.id
+        serializer = WineSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            set(serializer.errors['non_field_errors']),
+            set(['The wine line specified does not match the same winery'])
+        )
 
     def test_wine_endpoint_get(self):
         response = self.client.get(


### PR DESCRIPTION
Added validation to the wine endpoint, so when creating a wine the wine line must be from the same winery than the wine.

Also made winery's website not required anymore.