### PR TITLE
added occurrences endpoint

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework_nested import routers
 from api.views import (
     EventsView,
     EventCategoryView,
+    EventOccurrencesView,
     FileUploadView,
     MapsView,
     RatingView,
@@ -35,6 +36,9 @@ ratings_router = routers.NestedDefaultRouter(router, r'events', lookup='event')
 ratings_router.register(r'ratings', RatingView, basename='event-ratings')
 # router.register(r'rates', RatingView, basename='rates')
 
+event_occurrences_router = routers.NestedDefaultRouter(router, r'events', lookup='event')
+event_occurrences_router.register(r'occurrences', EventOccurrencesView, basename='event-occurrences')
+
 router.register(r'tags', TagView, basename='tags')
 router.register(r'event-categories', EventCategoryView, basename='event-categories')
 router.register(r'reservations', ReservationView, basename='reservations')
@@ -44,6 +48,7 @@ urlpatterns = [
     path('', include(wine_lines_router.urls)),
     path('', include(wines_router.urls)),
     path('', include(ratings_router.urls)),
+    path('', include(event_occurrences_router.urls)),
     path('maps/', MapsView.as_view()),
     path('restaurants/', RestaurantsView.as_view(), name='restaurants'),
     path('varietals/', VarietalsView.as_view(), name='varietals'),

--- a/api/views.py
+++ b/api/views.py
@@ -28,6 +28,7 @@ from .models import (
 )
 from .serializers import (
     EventCategorySerializer,
+    EventOccurrenceSerializer,
     EventSerializer,
     RateSerializer,
     ReservationSerializer,
@@ -262,3 +263,22 @@ class RestaurantsView(APIView):
 
         restaurants = EventSerializer(query, many=True)
         return Response(restaurants.data, status=status.HTTP_200_OK)
+
+
+class EventOccurrencesView(viewsets.ModelViewSet):
+    serializer_class = EventOccurrenceSerializer
+    model_class = EventOccurrence
+
+    def create(self, request, event_pk):
+        serializer = EventOccurrenceSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        occurrence = serializer.create(serializer.validated_data, event_pk)
+        return Response(
+            {'url': reverse('event-occurrences-detail', kwargs={'event_pk': event_pk, 'pk': occurrence.id})},
+            status=status.HTTP_201_CREATED)
+
+    def get_queryset(self):
+        event = get_object_or_404(Event, id=self.kwargs['event_pk'])
+        return EventOccurrence.objects.filter(event=event.id)


### PR DESCRIPTION
Added endpoint event/1/occurrences
This supports listing, retrieving, updating and deleting for individual occurrences of an event, which can be useful to edit events.
We should consider to stop using occurrences expanded on the event serializer, but they are still serialized for compatibility reasons.