### PR TITLE
Cancellation reason added for mails.

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -19,3 +19,5 @@ RESERVATION_STATUS = [
     (RESERVATION_CANCELLED, 'Cancelled'),
     (RESERVATION_PAIDOUT, 'Paid Out'),
 ]
+
+DEFAULT_CANCELLATION_REASON = 'El evento se cancela por motivos de fuerza mayor'

--- a/api/models.py
+++ b/api/models.py
@@ -144,13 +144,13 @@ class Event(models.Model):
                 dates.append(day)
         return dates
 
-    def cancel(self):
+    def cancel(self, reason):
         self.cancelled = datetime.now()
         occurrences = self.occurrences.filter(start__gt=date.today())
         for occurrence in occurrences:
             reservations = occurrence.reservation_set.all()
             for reservation in reservations:
-                reservation.cancel()
+                reservation.cancel(reason)
         self.save()
         success_message = 'The event has been cancelled'
         return success_message
@@ -209,7 +209,7 @@ class Reservation(models.Model):
     def __str__(self):
         return '{}: {}, {}'.format(str(self.id), self.user.first_name, str(self.paid_amount))
 
-    def cancel(self):
+    def cancel(self, reason):
         if self.status == RESERVATION_CANCELLED:
             return 'The reservation was already cancelled'
 
@@ -230,6 +230,7 @@ class Reservation(models.Model):
                 'winery': self.event_occurrence.event.winery.name,
                 'id': self.id,
                 'date': self.event_occurrence.start,
+                'reason': reason,
             }
         )
         plain_message = strip_tags(html_message)

--- a/api/tests/test_events.py
+++ b/api/tests/test_events.py
@@ -162,6 +162,7 @@ class TestEvents(TestCase):
         }
 
         self.event_required_fields = ['name', 'description', 'price', 'categories', 'schedule', 'vacancies']
+        self.cancel_reason = {'reason': 'ExampleReason'}
         self.client = Client()
 
     def test_dates_between_threshold(self):
@@ -784,7 +785,7 @@ class TestEvents(TestCase):
         self.client.force_login(self.winery_user)
         event = Event.objects.create(name='Test Event', description='Desc 1', winery=self.winery, price=0.0)
         res = self.client.post(
-            reverse('event-cancel-event', kwargs={'pk': event.id})
+                reverse('event-cancel-event', kwargs={'pk': event.id}), self.cancel_reason
         )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         event.refresh_from_db()

--- a/api/tests/test_reservation.py
+++ b/api/tests/test_reservation.py
@@ -61,6 +61,7 @@ class TestReservation(TestCase):
                 'observations': 'observations',
         }
         self.required_fields = set(['attendee_number', 'paid_amount', 'event_occurrence'])
+        self.cancellation_reason = {'reason': 'exampleReason'}
         self.client = Client()
 
     def test_reservation_creation(self):
@@ -209,7 +210,7 @@ class TestReservation(TestCase):
 
         # cancel the reservation
         response = self.client.post(
-            reverse('reservations-cancel-reservation', kwargs={'pk': reservation.id})
+            reverse('reservations-cancel-reservation', kwargs={'pk': reservation.id}), self.cancellation_reason
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         reservation.refresh_from_db()
@@ -232,7 +233,7 @@ class TestReservation(TestCase):
         old_reservation = Reservation.objects.create(**self.valid_creation_data)
 
         self.client.post(
-            reverse('event-cancel-event', kwargs={'pk': self.event.id})
+            reverse('event-cancel-event', kwargs={'pk': self.event.id}), self.cancellation_reason
         )
         reservation.refresh_from_db()
         self.assertEqual(reservation.status, RESERVATION_CANCELLED)

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from . import DEFAULT_CANCELLATION_REASON
 
 from django.db.models import Count, F
 from django.db.models.functions import ExtractMonth
@@ -116,8 +117,14 @@ class EventsView(viewsets.ModelViewSet):
             return Response({'detail': 'Event already cancelled'}, status=status.HTTP_200_OK)
         if not getattr(request.user, 'winery', None) or request.user.winery.id != event.winery.id:
             return Response({'detail': 'Access Denied'}, status=status.HTTP_403_FORBIDDEN)
-        message = event.cancel()
-        return Response({'detail': message}, status=status.HTTP_200_OK)
+        try:
+            reason = request.data.get('reason', DEFAULT_CANCELLATION_REASON)
+            message = event.cancel(reason)
+            return Response({'detail': message}, status=status.HTTP_200_OK)
+        except Exception:
+            return Response(
+                {"errors": "Bad Request."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
     def get_queryset(self):
         all_events = Event.objects.filter(
@@ -347,8 +354,14 @@ class ReservationView(viewsets.ModelViewSet):
         reservation = get_object_or_404(Reservation, id=pk)
         if reservation.user.id != request.user.id:
             return Response({'detail': 'Permission Denied'}, status=status.HTTP_403_FORBIDDEN)
-        message = reservation.cancel()
-        return Response({'detail': message}, status=status.HTTP_200_OK)
+        try:
+            reason = request.data.get('reason', DEFAULT_CANCELLATION_REASON)
+            message = reservation.cancel(reason)
+            return Response({'detail': message}, status=status.HTTP_200_OK)
+        except Exception:
+            return Response(
+                {"errors": "Bad Request."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
 
 class VarietalsView(APIView):

--- a/mail-templates/mail_template.html
+++ b/mail-templates/mail_template.html
@@ -332,6 +332,9 @@
                                             Numero de reserva: {{id}}
                                             <br>
                                             Fecha de la reserva: {{date}}
+                                            <br>
+                                            Motivo de cancelacion: {{reason}}
+                                            <br>
                                         </a>
                                       </td>
                                     </tr>


### PR DESCRIPTION
Cancellation reason added to cancel_event and cancel_reservation endpoint to send in emails. 
No persistence in the reservations models, I'm not sure if the last is required.